### PR TITLE
fix PMT

### DIFF
--- a/include/mpegts.hrl
+++ b/include/mpegts.hrl
@@ -16,6 +16,7 @@
 -define(EIT_PID, 18). % EPG
 -define(RST_PID, 19).
 -define(TDT_PID, 20). % TOT here
+-define(SPECIAL_PID, 4095).
 
 -define(MPEGTS_STREAMID_MPEG2, 2).
 -define(MPEGTS_STREAMID_MPGA1, 3).

--- a/src/mpegts_reader.erl
+++ b/src/mpegts_reader.erl
@@ -130,7 +130,8 @@ init([Options]) ->
     #stream{handler = psi, pid = ?SDT_PID},
     #stream{handler = psi, pid = ?EIT_PID},
     #stream{handler = psi, pid = ?RST_PID},
-    #stream{handler = psi, pid = ?TDT_PID}
+    #stream{handler = psi, pid = ?TDT_PID},
+    #stream{handler = psi, pid = ?SPECIAL_PID}
   ], dump_psi = DumpPSI}}.
 
 


### PR DESCRIPTION
Логи событий:
При статическом анализе кода (в двух направлениях - от вывода сообщения "New PID" и от функции init()),
докопался до того, что не прилетает пакет с PAT-таблицей (PID = 0), то есть полностью отсутсвует PSI
    Добавил в decode_ts отладочный вывод, сравнил логи.

Первая идея (тупиковая) -
    попытка "угадать" PAT таблицу на лету, естественно, ни к чему не привела, так как мы не знаем какими хендлерами обрабатывать пакет.
    Проверил эту догадку:
    для этого в decode_ts добавил ветку, которая срабатывает, в случае, если мы не получали пакет с PID = 0, и пришел непонятный пакет:
        case lists:keytake(Pid, #stream.pid, Pids) of
        ...
            false when DumpPSI == [] ->
                io:format("====DEBUG-UNKNOWN-PID, but we have not PSI:~tp~n", [Pid]),
                Stream = #stream{handler = pci, pid = Pid},
                DecoderNew = insert_pid(Stream, Decoder),
                decode_ts(Packet, DecoderNew);
    Теперь пришли к ожидаемой ошибке "Отсутствие нужного хендлера", потому что для всех пакетов вызывается хендлер для обработки PSI
        "** exception error: undefined function mpegts_reader:pci/3"

Вторая идея - при анализе PID'ов пакетов видим первый PID(4095 (0x0FFF)), немного отличающийся от других, но сильно похож на служебный PID (на нулевой пакет 0x1FFF).
    Так как пакет первый, и выяснили, что нет возможности угадать PSI - пробуем представить его как пакет, который хранит PSI.
    Для этого добавим новый psi-handler для этого PID:

    mpegts.hrl:
        -define(SPECIAL_PID, 4095).

    mpegts_reader.erl:
        init([Options]) ->
            ....
            #stream{handler = psi, pid = ?SPECIAL_PID}
          ], dump_psi = DumpPSI}}.

 Заработало! Получили видео-фреймы!

 Пока не понимаем, что конкретно обозначает данный PID, гуглим "MPEG-TS special PID"
 Находим полезную инфу - http://www.konturm.ru/tech.php?id=mpeg, из которой выясняем, что данный идентификатор, скорее всего, имеет отношение к PMT (Program Map Table) так как входит в диапазон 10h..1FFEh
